### PR TITLE
Change input cache targets

### DIFF
--- a/.github/workflows/pullRequestWorkflow.yml
+++ b/.github/workflows/pullRequestWorkflow.yml
@@ -9,7 +9,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "16.15.0"
-      - uses: ./
+      - name: mangs/super-cache-action
+        uses: ./
         id: super-cache
       - if: steps.super-cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/pullRequestWorkflow.yml
+++ b/.github/workflows/pullRequestWorkflow.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "16.15.0"
-      - name: mangs/super-cache-action
+      - name: Run mangs/super-cache-action
         uses: ./
         id: super-cache
       - if: steps.super-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/pullRequestWorkflow.yml
+++ b/.github/workflows/pullRequestWorkflow.yml
@@ -8,10 +8,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.14.2"
-      - name: mangs/node-modules-super-cache-action
+          node-version: "16.15.0"
+      - uses: ./
         id: super-cache
-        uses: ./
+      - if: steps.super-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - uses: actions/setup-node@v3
+      - uses: mangs/super-cache-action@v3
+        id: super-cache
       - if: steps.super-cache.outputs.cache-hit != 'true'
         run: npm ci
 

--- a/.github/workflows/pullRequestWorkflow.yml
+++ b/.github/workflows/pullRequestWorkflow.yml
@@ -14,11 +14,5 @@ jobs:
       - if: steps.super-cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - uses: actions/setup-node@v3
-      - uses: mangs/super-cache-action@v3
-        id: super-cache
-      - if: steps.super-cache.outputs.cache-hit != 'true'
-        run: npm ci
-
       # Task execution
       - run: npm run validate:formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Change action name from `dependency-super-cache-action` to `super-cache-action` to reflect its use beyond just caching dependencies (e.g. ESLint cache)
-- Renamed input parameter `dependencies_to_cache` to `cache_targets` for clarity purposes
+- Renamed input parameter `dependencies_to_cache` to `cache_targets` for clarity purposes when caching non-dependency targets
 - Updated dependencies
 
 ## 2.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Change action name from `dependency-super-cache-action` to `super-cache-action` to reflect its use beyond just caching dependencies (e.g. ESLint cache)
-- Renamed input parameter `dependencies_to_cache` to `cache_targets` for clarity purposes when caching non-dependency targets
+- Renamed input parameter `dependencies_to_cache` to `cache-targets` for clarity purposes when caching non-dependency targets
 - Updated dependencies
 
 ## 2.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.0.0
 
+- Change action name from `dependency-super-cache-action` to `super-cache-action` to reflect its use beyond just caching dependencies (e.g. ESLint cache)
 - Renamed input parameter `dependencies_to_cache` to `cache_targets` for clarity purposes
 - Updated dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.0
+
+- Renamed input parameter `dependencies_to_cache` to `cache_targets` for clarity purposes
+- Updated dependencies
+
 ## 2.0.3
 
 - Update the readme to reference the correct action version; `v1` was mistakenly referenced instead of `v2`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Simple GitHub Action that improves cache performance over `actions/cache`'s reco
 - uses: mangs/super-cache-action@v3
   id: super-cache
   with:
-    cache_targets: |
+    cache-targets: |
       ./.eslintcache
       ./node_modules
 - if: steps.super-cache.outputs.cache-hit != 'true'
@@ -30,7 +30,7 @@ Simple GitHub Action that improves cache performance over `actions/cache`'s reco
 
 | Name            | Required | Default Value    | Descripition                                                                              |
 | --------------- | -------- | ---------------- | ----------------------------------------------------------------------------------------- |
-| `cache_targets` | N        | `./node_modules` | Single- or multi-line string wherein each line targets a resource to cache; can use globs |
+| `cache-targets` | N        | `./node_modules` | Single- or multi-line string wherein each line targets a resource to cache; can use globs |
 
 ## Action Outputs
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ Simple GitHub Action that improves cache performance over `actions/cache`'s reco
 
 ## Action Outputs
 
-| Name        | Data Type | Descripition                                                              |
-| ----------- | --------- | ------------------------------------------------------------------------- |
-| `cache-hit` | Boolean   | A boolean value indicating if a match was found in the repository's cache |
+| Name        | Descripition                                                              |
+| ----------- | ------------------------------------------------------------------------- |
+| `cache-hit` | A boolean value indicating if a match was found in the repository's cache |

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-# `mangs/dependency-super-cache-action`
+# `mangs/super-cache-action`
 
-Simple GitHub Action that improves dependency cache performance over `actions/cache`'s recommendations for Node.js projects
+Simple GitHub Action that improves cache performance over `actions/cache`'s recommendations for Node.js projects
 
 ## Simple Example
 
 ```yaml
 - uses: actions/setup-node@v3
-  with:
-    node-version: "16.15.0"
-- id: super-cache
-  uses: mangs/dependency-super-cache-action@v2
+- uses: mangs/super-cache-action@v3
+  id: super-cache
 - if: steps.super-cache.outputs.cache-hit != 'true'
   run: npm ci
 ```
@@ -18,10 +16,8 @@ Simple GitHub Action that improves dependency cache performance over `actions/ca
 
 ```yaml
 - uses: actions/setup-node@v3
-  with:
-    node-version: "16.15.0"
-- id: super-cache
-  uses: mangs/dependency-super-cache-action@v2
+- uses: mangs/super-cache-action@v3
+  id: super-cache
   with:
     cache_targets: |
       ./.eslintcache

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ Simple GitHub Action that improves cache performance over `actions/cache`'s reco
 
 ## Action Outputs
 
-| Name        | Descripition                                                                                                              |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `cache-hit` | A boolean value indicating whether or not `cache-targets` were fetched from cache and applied to the current workflow run |
+| Name        | Descripition                                                                                                  |
+| ----------- | ------------------------------------------------------------------------------------------------------------- |
+| `cache-hit` | A boolean value indicating if `cache-targets` were fetched from cache and applied to the current workflow run |

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Simple GitHub Action that improves dependency cache performance over `actions/ca
 
 ## Action Inputs
 
-| Name                    | Required | Default Value    | Descripition                                                                                |
-| ----------------------- | -------- | ---------------- | ------------------------------------------------------------------------------------------- |
-| `dependencies_to_cache` | N        | `./node_modules` | Single- or multi-line string wherein each line targets dependencies to cache; can use globs |
+| Name                    | Required | Default Value    | Descripition                                                                              |
+| ----------------------- | -------- | ---------------- | ----------------------------------------------------------------------------------------- |
+| `dependencies_to_cache` | N        | `./node_modules` | Single- or multi-line string wherein each line targets a resource to cache; can use globs |
 
 ## Action Outputs
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ Simple GitHub Action that improves cache performance over `actions/cache`'s reco
 
 ## Action Outputs
 
-| Name        | Descripition                                                              |
-| ----------- | ------------------------------------------------------------------------- |
-| `cache-hit` | A boolean value indicating if a match was found in the repository's cache |
+| Name        | Descripition                                                                                                              |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `cache-hit` | A boolean value indicating whether or not `cache-targets` were fetched from cache and applied to the current workflow run |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simple GitHub Action that improves dependency cache performance over `actions/ca
 ```yaml
 - uses: actions/setup-node@v3
   with:
-    node-version: "16.14.2"
+    node-version: "16.15.0"
 - id: super-cache
   uses: mangs/dependency-super-cache-action@v2
 - if: steps.super-cache.outputs.cache-hit != 'true'
@@ -19,11 +19,11 @@ Simple GitHub Action that improves dependency cache performance over `actions/ca
 ```yaml
 - uses: actions/setup-node@v3
   with:
-    node-version: "16.14.2"
+    node-version: "16.15.0"
 - id: super-cache
   uses: mangs/dependency-super-cache-action@v2
   with:
-    dependencies_to_cache: |
+    cache_targets: |
       ./.eslintcache
       ./node_modules
 - if: steps.super-cache.outputs.cache-hit != 'true'
@@ -32,9 +32,9 @@ Simple GitHub Action that improves dependency cache performance over `actions/ca
 
 ## Action Inputs
 
-| Name                    | Required | Default Value    | Descripition                                                                              |
-| ----------------------- | -------- | ---------------- | ----------------------------------------------------------------------------------------- |
-| `dependencies_to_cache` | N        | `./node_modules` | Single- or multi-line string wherein each line targets a resource to cache; can use globs |
+| Name            | Required | Default Value    | Descripition                                                                              |
+| --------------- | -------- | ---------------- | ----------------------------------------------------------------------------------------- |
+| `cache_targets` | N        | `./node_modules` | Single- or multi-line string wherein each line targets a resource to cache; can use globs |
 
 ## Action Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: mangs/super-cache-action
 author: Eric L. Goldstein
 description: Simple GitHub Action that improves cache performance over actions/cache's recommendations for Node.js projects
 inputs:
-  cache_targets:
+  cache-targets:
     default: "./node_modules"
     description: Single- or multi-line string wherein each line targets a resource to cache; can use globs
     required: false
@@ -20,5 +20,5 @@ runs:
     - uses: actions/cache@v3
       id: npm-cache
       with:
-        path: ${{ inputs.cache_targets }}
+        path: ${{ inputs.cache-targets }}
         key: ${{ runner.os }}-npm-v${{ steps.npm-capture.outputs.version-number }}-${{ hashFiles('./package-lock.json') }}

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,9 @@ name: mangs/dependency-super-cache-action
 author: Eric L. Goldstein
 description: Simple GitHub Action that improves dependency cache performance over actions/cache's recommendations for Node.js projects
 inputs:
-  dependencies_to_cache:
+  cache_targets:
     default: "./node_modules"
-    description: Single- or multi-line string wherein each line targets dependencies to cache; can use globs
+    description: Single- or multi-line string wherein each line targets a resource to cache; can use globs
     required: false
 outputs:
   cache-hit:
@@ -20,5 +20,5 @@ runs:
     - uses: actions/cache@v3
       id: npm-cache
       with:
-        path: ${{ inputs.dependencies_to_cache }}
+        path: ${{ inputs.cache_targets }}
         key: ${{ runner.os }}-npm-v${{ steps.npm-capture.outputs.version-number }}-${{ hashFiles('./package-lock.json') }}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: mangs/dependency-super-cache-action
+name: mangs/super-cache-action
 author: Eric L. Goldstein
-description: Simple GitHub Action that improves dependency cache performance over actions/cache's recommendations for Node.js projects
+description: Simple GitHub Action that improves cache performance over actions/cache's recommendations for Node.js projects
 inputs:
   cache_targets:
     default: "./node_modules"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dependency-super-cache-action",
+  "name": "super-cache-action",
   "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "dependency-super-cache-action",
+      "name": "super-cache-action",
       "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "dependency-super-cache-action",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependency-super-cache-action",
-      "version": "2.0.3",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@vscode/ripgrep": "1.14.2",
-        "prettier": "2.6.1"
+        "prettier": "2.6.2"
       },
       "engines": {
         "node": ">=16.13.0"
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "dependencies": {
         "agent-base": "6",
@@ -76,9 +76,9 @@
       "dev": true
     },
     "node_modules/prettier": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
-      "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -127,9 +127,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "requires": {
         "agent-base": "6",
@@ -143,9 +143,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
-      "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true
     },
     "proxy-from-env": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-super-cache-action",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "author": "Eric L. Goldstein",
   "description": "Simple GitHub Action that improves dependency cache performance over actions/cache's recommendations for Node.js projects",
   "keywords": [
@@ -35,6 +35,6 @@
   },
   "devDependencies": {
     "@vscode/ripgrep": "1.14.2",
-    "prettier": "2.6.1"
+    "prettier": "2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "dependency-super-cache-action",
+  "name": "super-cache-action",
   "version": "3.0.0",
   "author": "Eric L. Goldstein",
-  "description": "Simple GitHub Action that improves dependency cache performance over actions/cache's recommendations for Node.js projects",
+  "description": "Simple GitHub Action that improves cache performance over actions/cache's recommendations for Node.js projects",
   "keywords": [
     "cache",
     "github action",
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mangs/dependency-super-cache-action.git"
+    "url": "git+https://github.com/mangs/super-cache-action.git"
   },
   "engines": {
     "node": ">=16.13.0"
@@ -25,7 +25,7 @@
     "format:code:json": "prettier --write --no-editorconfig \"**/*.json\"",
     "format:code:markdown": "prettier --write --no-editorconfig \"**/*.md\"",
     "format:code:yaml": "prettier --write --no-editorconfig \"**/*.yml\"",
-    "list:todo-comments:ripgrep": "node_modules/@vscode/ripgrep/bin/rg --only-matching '(TODO|FIXME):[a-zA-Z0-9\\t .,;?]+'",
+    "list:todo-comments": "node_modules/@vscode/ripgrep/bin/rg --only-matching '(TODO|FIXME):[a-zA-Z0-9\\t .,;?]+'",
     "reinstall": "npm run --silent delete:node_modules && npm run --silent delete:package-lock && npm i",
     "reinstall:use-lock-file": "npm run --silent delete:node_modules && npm ci",
     "validate:formatting": "prettier --check --no-editorconfig .",


### PR DESCRIPTION
- Version bump to `3.0.0`
- Change action name from `dependency-super-cache-action` to `super-cache-action` to reflect its use beyond just caching dependencies (e.g. ESLint cache)
- Renamed input parameter `dependencies_to_cache` to `cache-targets` for clarity purposes when caching non-dependency targets
- Updated dependencies