### PR TITLE
Add support for choosing either `npm`, `pnpm`, or `yarn` as the package manager target for caching

### DIFF
--- a/.github/workflows/publishReleaseNotesWorkflow.yml
+++ b/.github/workflows/publishReleaseNotesWorkflow.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: mangs/simple-release-notes-action@v1
+      - uses: mangs/simple-release-notes-action@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pullRequestWorkflow.yml
+++ b/.github/workflows/pullRequestWorkflow.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.15.0"
+          node-version: "16.15.1"
       - name: Run mangs/super-cache-action
         uses: ./
         id: super-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.1.0
+
+- Add support for choosing either `npm`, `pnpm`, or `yarn` as the package manager target for caching
+- Update workflows to use `mangs/simple-release-notes-action@v2` and Node.js version `16.15.1`
+
 ## 3.0.0
 
 - Change action name from `dependency-super-cache-action` to `super-cache-action` to reflect its use beyond just caching dependencies (e.g. ESLint cache)

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Simple GitHub Action that improves cache performance over `actions/cache`'s reco
 
 ## Action Inputs
 
-| Name            | Required | Default Value    | Descripition                                                                              |
-| --------------- | -------- | ---------------- | ----------------------------------------------------------------------------------------- |
-| `cache-targets` | N        | `./node_modules` | Single- or multi-line string wherein each line targets a resource to cache; can use globs |
+| Name              | Required | Default Value    | Descripition                                                                              |
+| ----------------- | -------- | ---------------- | ----------------------------------------------------------------------------------------- |
+| `cache-targets`   | N        | `./node_modules` | Single- or multi-line string wherein each line targets a resource to cache; can use globs |
+| `package-manager` | N        | `npm`            | Package manager target for caching operations                                             |
 
 ## Action Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -23,15 +23,15 @@ runs:
       shell: bash
     - if: inputs.package-manager == 'npm'
       id: npm
-      run: echo "::set-output name=hash::${{ hashFiles('./package-lock.json') }}"
+      run: echo "::set-output name=hash::${{ hashFiles('**/package-lock.json') }}"
       shell: bash
     - if: inputs.package-manager == 'pnpm'
       id: pnpm
-      run: echo "::set-output name=hash::${{ hashFiles('./pnpm-lock.yaml') }}"
+      run: echo "::set-output name=hash::${{ hashFiles('**/pnpm-lock.yaml') }}"
       shell: bash
     - if: inputs.package-manager == 'yarn'
       id: yarn
-      run: echo "::set-output name=hash::${{ hashFiles('./yarn.lock') }}"
+      run: echo "::set-output name=hash::${{ hashFiles('**/yarn.lock') }}"
       shell: bash
     - if: inputs.package-manager == 'npm' || inputs.package-manager == 'pnpm' || inputs.package-manager == 'yarn'
       uses: actions/cache@v3

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
     #   id: yarn-capture
     #   run: echo "::set-output name=version-number::$(yarn --version)"
     #   shell: bash
-    - if: inputs.package-manager == "npm" || inputs.package-manager == "pnpm" || inputs.package-manager == "yarn"
+    - if: inputs.package-manager == 'npm' || inputs.package-manager == 'pnpm' || inputs.package-manager == 'yarn'
       uses: actions/cache@v3
       id: package-manager-cache
       with:

--- a/action.yml
+++ b/action.yml
@@ -24,12 +24,15 @@ runs:
     - if: inputs.package-manager == 'npm'
       id: npm
       run: echo "::set-output name=hash::${{ hashFiles('./package-lock.json') }}"
+      shell: bash
     - if: inputs.package-manager == 'pnpm'
       id: pnpm
       run: echo "::set-output name=hash::${{ hashFiles('./pnpm-lock.yaml') }}"
+      shell: bash
     - if: inputs.package-manager == 'yarn'
       id: yarn
       run: echo "::set-output name=hash::${{ hashFiles('./yarn.lock') }}"
+      shell: bash
     - if: inputs.package-manager == 'npm' || inputs.package-manager == 'pnpm' || inputs.package-manager == 'yarn'
       uses: actions/cache@v3
       id: package-manager-cache

--- a/action.yml
+++ b/action.yml
@@ -3,22 +3,41 @@ author: Eric L. Goldstein
 description: Simple GitHub Action that improves cache performance over actions/cache's recommendations for Node.js projects
 inputs:
   cache-targets:
-    default: "./node_modules"
+    default: ./node_modules
     description: Single- or multi-line string wherein each line targets a resource to cache; can use globs
+    required: false
+  package-manager:
+    default: npm
+    description: Package manager target for caching operations
     required: false
 outputs:
   cache-hit:
     description: A boolean value indicating if a match was found in the repository's cache
-    value: ${{ steps.npm-cache.outputs.cache-hit }}
+    value: ${{ steps.package-manager-cache.outputs.cache-hit }}
 runs:
   using: composite
   steps:
-    - name: Capture NPM version number
-      id: npm-capture
-      run: echo "::set-output name=version-number::$(npm -v)"
+    - name: Capture package manager version number
+      id: capture
+      run: echo "::set-output name=version-number::$(${{ inputs.package-manager }} --version)"
       shell: bash
-    - uses: actions/cache@v3
-      id: npm-cache
+    # - name: Capture NPM version number
+    #   id: npm-capture
+    #   run: echo "::set-output name=version-number::$(${{ inputs.package-manager }} --version)"
+    #   shell: bash
+    # - if: inputs.package-manager == "pnpm"
+    #   name: Capture PNPM version number
+    #   id: pnpm-capture
+    #   run: echo "::set-output name=version-number::$(pnpm --version)"
+    #   shell: bash
+    # - if: inputs.package-manager == "yarn"
+    #   name: Capture Yarn version number
+    #   id: yarn-capture
+    #   run: echo "::set-output name=version-number::$(yarn --version)"
+    #   shell: bash
+    - if: inputs.package-manager == "npm" || inputs.package-manager == "pnpm" || inputs.package-manager == "yarn"
+      uses: actions/cache@v3
+      id: package-manager-cache
       with:
         path: ${{ inputs.cache-targets }}
-        key: ${{ runner.os }}-npm-v${{ steps.npm-capture.outputs.version-number }}-${{ hashFiles('./package-lock.json') }}
+        key: ${{ runner.os }}-${{ inputs.package-manager }}-v${{ steps.capture.outputs.version-number }}-${{ hashFiles('./package-lock.json') }}

--- a/action.yml
+++ b/action.yml
@@ -21,23 +21,18 @@ runs:
       id: capture
       run: echo "::set-output name=version-number::$(${{ inputs.package-manager }} --version)"
       shell: bash
-    # - name: Capture NPM version number
-    #   id: npm-capture
-    #   run: echo "::set-output name=version-number::$(${{ inputs.package-manager }} --version)"
-    #   shell: bash
-    # - if: inputs.package-manager == "pnpm"
-    #   name: Capture PNPM version number
-    #   id: pnpm-capture
-    #   run: echo "::set-output name=version-number::$(pnpm --version)"
-    #   shell: bash
-    # - if: inputs.package-manager == "yarn"
-    #   name: Capture Yarn version number
-    #   id: yarn-capture
-    #   run: echo "::set-output name=version-number::$(yarn --version)"
-    #   shell: bash
+    - if: inputs.package-manager == 'npm'
+      id: npm
+      run: echo "::set-output name=hash::${{ hashFiles('./package-lock.json') }}"
+    - if: inputs.package-manager == 'pnpm'
+      id: pnpm
+      run: echo "::set-output name=hash::${{ hashFiles('./pnpm-lock.yaml') }}"
+    - if: inputs.package-manager == 'yarn'
+      id: yarn
+      run: echo "::set-output name=hash::${{ hashFiles('./yarn.lock') }}"
     - if: inputs.package-manager == 'npm' || inputs.package-manager == 'pnpm' || inputs.package-manager == 'yarn'
       uses: actions/cache@v3
       id: package-manager-cache
       with:
         path: ${{ inputs.cache-targets }}
-        key: ${{ runner.os }}-${{ inputs.package-manager }}-v${{ steps.capture.outputs.version-number }}-${{ hashFiles('./package-lock.json') }}
+        key: ${{ runner.os }}-${{ inputs.package-manager }}-v${{ steps.capture.outputs.version-number }}-${{ steps.npm.outputs.hash }}${{ steps.pnpm.outputs.hash }}${{ steps.yarn.outputs.hash }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "super-cache-action",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "super-cache-action",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@vscode/ripgrep": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-cache-action",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "Eric L. Goldstein",
   "description": "Simple GitHub Action that improves cache performance over actions/cache's recommendations for Node.js projects",
   "keywords": [


### PR DESCRIPTION
- Version bump to `3.1.0`
- Add support for choosing either `npm`, `pnpm`, or `yarn` as the package manager target for caching
- Update workflows to use `mangs/simple-release-notes-action@v2` and Node.js version `16.15.1`