### PR TITLE
Update documentation about `cache-hit` to be more clear about its data type and possible values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.1
+
+- Update documentation about `cache-hit` to be more clear about its data type and possible values
+
 ## 3.1.0
 
 - Add support for choosing either `npm`, `pnpm`, or `yarn` as the package manager target for caching

--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ Simple GitHub Action that improves cache performance over `actions/cache`'s reco
 
 ## Action Outputs
 
-| Name        | Descripition                                                                                                  |
-| ----------- | ------------------------------------------------------------------------------------------------------------- |
-| `cache-hit` | A boolean value indicating if `cache-targets` were fetched from cache and applied to the current workflow run |
+| Name        | Descripition                                                                                                                               |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `cache-hit` | A string containing either `true` or `false` indicating if `cache-targets` were fetched from cache and applied to the current workflow run |

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
 outputs:
   cache-hit:
-    description: A boolean value indicating if a match was found in the repository's cache
+    description: A string containing either 'true' or 'false' indicating if 'cache-targets' were fetched from cache and applied to the current workflow run
     value: ${{ steps.package-manager-cache.outputs.cache-hit }}
 runs:
   using: composite

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "super-cache-action",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "super-cache-action",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "@vscode/ripgrep": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-cache-action",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "Eric L. Goldstein",
   "description": "Simple GitHub Action that improves cache performance over actions/cache's recommendations for Node.js projects",
   "keywords": [


### PR DESCRIPTION
- Version bump to `3.1.1`
- Update documentation about `cache-hit` to be more clear about its data type and possible values