### PR TITLE
Update workflow Ubuntu & Node versions, update dependencies

### DIFF
--- a/.github/workflows/publishReleaseNotesWorkflow.yml
+++ b/.github/workflows/publishReleaseNotesWorkflow.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: mangs/simple-release-notes-action@v2

--- a/.github/workflows/pullRequestWorkflow.yml
+++ b/.github/workflows/pullRequestWorkflow.yml
@@ -3,12 +3,12 @@ on: pull_request
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.15.1"
+          node-version: "16.17.0"
       - name: Run mangs/super-cache-action
         uses: ./
         id: super-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.3
+
+- Updated workflows to use operating system `ubuntu-22.04` and Node.js version `16.17.0`
+- Added the [`packageManager` field to `package.json`](https://nodejs.org/dist/latest-v16.x/docs/api/all.html#all_packages_packagemanager) to enforce the use of NPM version `8.15.0` for environments with [Corepack](https://nodejs.org/dist/latest-v16.x/docs/api/corepack.html) enabled
+- Update dependencies to latest
+
 ## 3.1.2
 
 - Update dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "super-cache-action",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "super-cache-action",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "devDependencies": {
         "@vscode/ripgrep": "1.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-cache-action",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "author": "Eric L. Goldstein",
   "description": "Simple GitHub Action that improves cache performance over actions/cache's recommendations for Node.js projects",
   "keywords": [
@@ -18,6 +18,7 @@
   "engines": {
     "node": ">=16.13.0"
   },
+  "packageManager": "npm@8.15.0",
   "scripts": {
     "delete:node_modules": "rm -rf node_modules",
     "delete:package-lock": "rm -f package-lock.json",


### PR DESCRIPTION
- Version bump to `3.1.3`
- Updated workflows to use operating system `ubuntu-22.04` and Node.js version `16.17.0`
- Added the [`packageManager` field to `package.json`](https://nodejs.org/dist/latest-v16.x/docs/api/all.html#all_packages_packagemanager) to enforce the use of NPM version `8.15.0` for environments with [Corepack](https://nodejs.org/dist/latest-v16.x/docs/api/corepack.html) enabled
- Update dependencies to latest