### PR TITLE
Replaced the use of `set-output` with the new environment files syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.1.4
+
+- Replaced the use of `set-output` with [the new environment files syntax](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
+- Update dependencies to latest
+
 ## 3.1.3
 
 - Updated workflows to use operating system `ubuntu-22.04` and Node.js version `16.17.0`

--- a/action.yml
+++ b/action.yml
@@ -19,19 +19,19 @@ runs:
   steps:
     - name: Capture package manager version number
       id: capture
-      run: echo "::set-output name=version-number::$(${{ inputs.package-manager }} --version)"
+      run: echo "version-number=$(${{ inputs.package-manager }} --version)" >> $GITHUB_OUTPUT
       shell: bash
     - if: inputs.package-manager == 'npm'
       id: npm
-      run: echo "::set-output name=hash::${{ hashFiles('**/package-lock.json') }}"
+      run: echo "hash=${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
       shell: bash
     - if: inputs.package-manager == 'pnpm'
       id: pnpm
-      run: echo "::set-output name=hash::${{ hashFiles('**/pnpm-lock.yaml') }}"
+      run: echo "hash=${{ hashFiles('**/pnpm-lock.yaml') }}" >> $GITHUB_OUTPUT
       shell: bash
     - if: inputs.package-manager == 'yarn'
       id: yarn
-      run: echo "::set-output name=hash::${{ hashFiles('**/yarn.lock') }}"
+      run: echo "hash=${{ hashFiles('**/yarn.lock') }}" >> $GITHUB_OUTPUT
       shell: bash
     - if: inputs.package-manager == 'npm' || inputs.package-manager == 'pnpm' || inputs.package-manager == 'yarn'
       uses: actions/cache@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,25 @@
 {
   "name": "super-cache-action",
-  "version": "3.1.3",
-  "lockfileVersion": 2,
+  "version": "3.1.4",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "super-cache-action",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "MIT",
       "devDependencies": {
-        "@vscode/ripgrep": "1.14.2",
-        "prettier": "2.7.1"
+        "@vscode/ripgrep": "1.15.0",
+        "prettier": "2.8.7"
       },
       "engines": {
         "node": ">=16.13.0"
       }
     },
     "node_modules/@vscode/ripgrep": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.14.2.tgz",
-      "integrity": "sha512-KDaehS8Jfdg1dqStaIPDKYh66jzKd5jy5aYEPzIv0JYFLADPsCSQPBUdsJVXnr0t72OlDcj96W05xt/rSnNFFQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.0.tgz",
+      "integrity": "sha512-qbLYP3XPTfS5a80+WnGvDLhsD01LDrs03zjbbtWWnvwt8G9hP3j8mc3ckaIid7pj86MBSTyUb/ECaIWmJIGBYw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -76,9 +76,9 @@
       "dev": true
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -91,64 +91,6 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
-    }
-  },
-  "dependencies": {
-    "@vscode/ripgrep": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.14.2.tgz",
-      "integrity": "sha512-KDaehS8Jfdg1dqStaIPDKYh66jzKd5jy5aYEPzIv0JYFLADPsCSQPBUdsJVXnr0t72OlDcj96W05xt/rSnNFFQ==",
-      "dev": true,
-      "requires": {
-        "https-proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "requires": {
-        "debug": "4"
-      }
-    },
-    "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true
-    },
-    "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-cache-action",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "author": "Eric L. Goldstein",
   "description": "Simple GitHub Action that improves cache performance over actions/cache's recommendations for Node.js projects",
   "keywords": [
@@ -23,19 +23,13 @@
     "delete:node_modules": "rm -rf node_modules",
     "delete:package-lock": "rm -f package-lock.json",
     "format:code": "prettier --write --no-editorconfig .",
-    "format:code:json": "prettier --write --no-editorconfig \"**/*.json\"",
-    "format:code:markdown": "prettier --write --no-editorconfig \"**/*.md\"",
-    "format:code:yaml": "prettier --write --no-editorconfig \"**/*.yml\"",
     "list:todo-comments": "node_modules/@vscode/ripgrep/bin/rg --only-matching '(TODO|FIXME):[a-zA-Z0-9\\t .,;?]+'",
     "reinstall": "npm run --silent delete:node_modules && npm run --silent delete:package-lock && npm i",
     "reinstall:use-lock-file": "npm run --silent delete:node_modules && npm ci",
-    "validate:formatting": "prettier --check --no-editorconfig .",
-    "validate:formatting:json": "prettier --check --no-editorconfig \"**/*.json\"",
-    "validate:formatting:markdown": "prettier --check --no-editorconfig \"**/*.md\"",
-    "validate:formatting:yaml": "prettier --check --no-editorconfig \"**/*.yml\""
+    "validate:formatting": "prettier --check --no-editorconfig ."
   },
   "devDependencies": {
-    "@vscode/ripgrep": "1.14.2",
-    "prettier": "2.7.1"
+    "@vscode/ripgrep": "1.15.0",
+    "prettier": "2.8.7"
   }
 }


### PR DESCRIPTION
- Version bump to `3.1.4`
- Replaced the use of `set-output` with [the new environment files syntax](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- Update dependencies to latest