### PR TITLE
Update major tag version on publish automatically with upgrade to `mangs/simple-release-notes-action@v3`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+../config/github/pullRequestTemplate.md

--- a/.github/workflows/publishReleaseNotesWorkflow.yml
+++ b/.github/workflows/publishReleaseNotesWorkflow.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: mangs/simple-release-notes-action@v2
+      - uses: actions/checkout@v4
+      - uses: mangs/simple-release-notes-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pullRequestWorkflow.yml
+++ b/.github/workflows/pullRequestWorkflow.yml
@@ -5,10 +5,10 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18.16.0"
+          node-version: "20.11.1"
       - name: Run mangs/super-cache-action
         uses: ./
         id: super-cache
@@ -16,4 +16,4 @@ jobs:
         run: npm ci
 
       # Task execution
-      - run: npm run validate:formatting
+      - run: npm run check:formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.3.0
+
+- Update major tag version on publish automatically with upgrade to `mangs/simple-release-notes-action@v3`
+- Update GitHub action workflow target Node.js version from `18.16.0` to `20.11.1`
+- Update action versions in GitHub actions workflows
+  - `actions/checkout`: `v3` -> `v4`
+  - `actions/setup-node`: `v3` -> `v4`
+  - `mangs/simple-release-notes-action`: `v2` -> `v3`
+- Rename `package.json` script `validate:formatting` to `check:formatting`
+- Remove dependency `@vscode/ripgrep` due to unreliable installs; use local Ripgrep version instead
+- Update dependencies to latest
+
 ## 3.2.0
 
 - Added action input `cache-key-suffix` to allow for cache key customization (e.g. separate development and production caches with the latter using `npm ci --production`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - `mangs/simple-release-notes-action`: `v2` -> `v3`
 - Rename `package.json` script `validate:formatting` to `check:formatting`
 - Remove dependency `@vscode/ripgrep` due to unreliable installs; use local Ripgrep version instead
+- Add pull request template file
 - Update dependencies to latest
 
 ## 3.2.0

--- a/config/github/pullRequestTemplate.md
+++ b/config/github/pullRequestTemplate.md
@@ -1,0 +1,8 @@
+**Pull Request Checklist**
+
+- [ ] Readme and changelog updates were made reflecting this PR's changes
+- [ ] Increase the project version number in [`package.json`](/package.json) following [Semantic Versioning](http://semver.org/)
+
+**Changes Included**
+
+- REPLACE_ME

--- a/config/github/pullRequestTemplate.md
+++ b/config/github/pullRequestTemplate.md
@@ -1,7 +1,7 @@
 **Pull Request Checklist**
 
 - [ ] Readme and changelog updates were made reflecting this PR's changes
-- [ ] Increase the project version number in [`package.json`](/package.json) following [Semantic Versioning](http://semver.org/)
+- [ ] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
 
 **Changes Included**
 

--- a/config/github/pullRequestTemplate.md
+++ b/config/github/pullRequestTemplate.md
@@ -1,7 +1,7 @@
 **Pull Request Checklist**
 
 - [ ] Readme and changelog updates were made reflecting this PR's changes
-- [ ] Increase the project version number in [`package.json`](/package.json) following [Semantic Versioning](http://semver.org/)
+- [ ] Increase the project version number in [`package.json`](./package.json) following [Semantic Versioning](http://semver.org/)
 
 **Changes Included**
 

--- a/config/github/pullRequestTemplate.md
+++ b/config/github/pullRequestTemplate.md
@@ -1,7 +1,7 @@
 **Pull Request Checklist**
 
 - [ ] Readme and changelog updates were made reflecting this PR's changes
-- [ ] Increase the project version number in [`package.json`](./package.json) following [Semantic Versioning](http://semver.org/)
+- [ ] Increase the project version number in [`package.json`](/package.json) following [Semantic Versioning](http://semver.org/)
 
 **Changes Included**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,100 +1,34 @@
 {
   "name": "super-cache-action",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "super-cache-action",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "devDependencies": {
-        "@vscode/ripgrep": "1.15.3",
-        "prettier": "2.8.8"
+        "prettier": "3.2.5"
       },
       "engines": {
-        "node": ">=16.13.0"
+        "node": ">=20.9.0"
       }
-    },
-    "node_modules/@vscode/ripgrep": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.3.tgz",
-      "integrity": "sha512-fCJP+4MRnhSTWw+GYAH93kSIomWYvdSe5206IqcHofBFcaFKR51XQNU0D5RB26Ps/5zRf5AQS26DIqqbMsB1Cw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-cache-action",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Eric L. Goldstein",
   "description": "Simple GitHub Action that improves cache performance over actions/cache's recommendations for Node.js projects",
   "keywords": [
@@ -16,20 +16,19 @@
     "url": "git+https://github.com/mangs/super-cache-action.git"
   },
   "engines": {
-    "node": ">=16.13.0"
+    "node": ">=20.9.0"
   },
-  "packageManager": "npm@9.5.1",
+  "packageManager": "npm@10.2.4",
   "scripts": {
+    "check:formatting": "prettier --check --no-editorconfig .",
     "delete:node_modules": "rm -rf node_modules",
     "delete:package-lock": "rm -f package-lock.json",
     "format:code": "prettier --write --no-editorconfig .",
-    "list:todo-comments": "node_modules/@vscode/ripgrep/bin/rg --only-matching '(TODO|FIXME):[a-zA-Z0-9\\t .,;?]+'",
+    "list:todo-comments": "rg --only-matching '(TODO|FIXME):[a-zA-Z0-9\\t .,;?-]+'",
     "reinstall": "npm run --silent delete:node_modules && npm run --silent delete:package-lock && npm i",
-    "reinstall:use-lock-file": "npm run --silent delete:node_modules && npm ci",
-    "validate:formatting": "prettier --check --no-editorconfig ."
+    "reinstall:use-lock-file": "npm run --silent delete:node_modules && npm ci"
   },
   "devDependencies": {
-    "@vscode/ripgrep": "1.15.3",
-    "prettier": "2.8.8"
+    "prettier": "3.2.5"
   }
 }


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)

**Changes Included**

- Version bump to `3.3.0`
- Update major tag version on publish automatically with upgrade to `mangs/simple-release-notes-action@v3`
- Update GitHub action workflow target Node.js version from `18.16.0` to `20.11.1`
- Update action versions in GitHub actions workflows
  - `actions/checkout`: `v3` -> `v4`
  - `actions/setup-node`: `v3` -> `v4`
  - `mangs/simple-release-notes-action`: `v2` -> `v3`
- Rename `package.json` script `validate:formatting` to `check:formatting`
- Remove dependency `@vscode/ripgrep` due to unreliable installs; use local Ripgrep version instead
- Add pull request template file
- Update dependencies to latest